### PR TITLE
make the FileStructure mode details and rm log variable

### DIFF
--- a/code/FilePointer.py
+++ b/code/FilePointer.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 r"""
 File Structure Exploitation
 
@@ -19,73 +18,171 @@ from __future__ import absolute_import
 from __future__ import division
 
 from pwnlib.context import context
-from pwnlib.log import getLogger
+from pwn import *
 
-log = getLogger(__name__)
+length = 0
+size = 'size'
+name = 'name'
 
-length=0
-size='size'
-name='name'
-
-variables={
-    0:{name:'flags',size:length},
-    1:{name:'_IO_read_ptr',size:length},
-    2:{name:'_IO_read_end',size:length},
-    3:{name:'_IO_read_base',size:length},
-    4:{name:'_IO_write_base',size:length},
-    5:{name:'_IO_write_ptr',size:length},
-    6:{name:'_IO_write_end',size:length},
-    7:{name:'_IO_buf_base',size:length},
-    8:{name:'_IO_buf_end',size:length},
-    9:{name:'_IO_save_base',size:length},
-    10:{name:'_IO_backup_base',size:length},
-    11:{name:'_IO_save_end',size:length},
-    12:{name:'markers',size:length},
-    13:{name:'chain',size:length},
-    14:{name:'fileno',size:4},
-    15:{name:'_flags2',size:4},
-    16:{name:'_old_offset',size:length},
-    17:{name:'_cur_column',size:2},
-    18:{name:'_vtable_offset',size:1},
-    19:{name:'_shortbuf',size:1},
-    20:{name:'unknown1',size:-4},
-    21:{name:'_lock',size:length},
-    22:{name:'_offset',size:8},
-    23:{name:'_codecvt',size:length},
-    24:{name:'_wide_data',size:length},
-    25:{name:'unknown2',size:length},
-    26:{name:'vtable',size:length}
+variables = {
+    0: {
+        name: '_flags',
+        size: length
+    },
+    1: {
+        name: '_IO_read_ptr',
+        size: length
+    },
+    2: {
+        name: '_IO_read_end',
+        size: length
+    },
+    3: {
+        name: '_IO_read_base',
+        size: length
+    },
+    4: {
+        name: '_IO_write_base',
+        size: length
+    },
+    5: {
+        name: '_IO_write_ptr',
+        size: length
+    },
+    6: {
+        name: '_IO_write_end',
+        size: length
+    },
+    7: {
+        name: '_IO_buf_base',
+        size: length
+    },
+    8: {
+        name: '_IO_buf_end',
+        size: length
+    },
+    9: {
+        name: '_IO_save_base',
+        size: length
+    },
+    10: {
+        name: '_IO_backup_base',
+        size: length
+    },
+    11: {
+        name: '_IO_save_end',
+        size: length
+    },
+    12: {
+        name: '_markers',
+        size: length
+    },
+    13: {
+        name: '_chain',
+        size: length
+    },
+    14: {
+        name: '_fileno',
+        size: 4
+    },
+    15: {
+        name: '_flags2',
+        size: 4
+    },
+    16: {
+        name: '_old_offset',
+        size: length
+    },
+    17: {
+        name: '_cur_column',
+        size: 2
+    },
+    18: {
+        name: '_vtable_offset',
+        size: 1
+    },
+    19: {
+        name: '_shortbuf',
+        size: 1
+    },
+    20: {
+        name: 'unknown1',
+        size: -4
+    },
+    21: {
+        name: '_lock',
+        size: length
+    },
+    22: {
+        name: '_offset',
+        size: 8
+    },
+    23: {
+        name: '_codecvt',
+        size: length
+    },
+    24: {
+        name: '_wide_data',
+        size: length
+    },
+    25: {
+        name: '_freeres_list',
+        size: length
+    },
+    26: {
+        name: '_freeres_buf',
+        size: length
+    },
+    27: {
+        name: '__pad5',
+        size: length
+    },
+    28: {
+        name: '_mode',
+        size: 4
+    },
+    29: {
+        name: '_unused2',
+        size: length
+    },
+    30: {
+        name: 'vtable',
+        size: length
+    }
 }
 
-defaults=[
- 'chain',
- '_lock',
- '_wide_data'
-]
+defaults = ['_chain', '_lock', '_wide_data']
+
 
 def get_defaults(null):
-        var={}
-        for i in defaults:
-            var[i]=null
-        return var
-
-def update_var(l):
-    var={}
-    for i in variables:
-        var[variables[i]['name']]=variables[i]['size']
-    for i in var:
-        if var[i]<=0:
-            var[i]+=l
-    if l==4:
-        var['unknown2']=56
-    else:
-        var['unknown2']=48
+    var = {}
+    for i in defaults:
+        var[i] = null
     return var
 
-def packit(s,l=8):
-    if l==0:
+
+def update_var(l):
+    var = {}
+    for i in variables:
+        var[variables[i]['name']] = variables[i]['size']
+    for i in var:
+        if var[i] <= 0:
+            var[i] += l
+    if l == 4:
+        var['_unused2'] = 40
+    else:
+        var['_unused2'] = 20
+    return var
+
+
+def packit(s, l=8):
+    if l == 0:
         return ''
-    return hex(s).replace('0x','').rjust(2*l,'0').replace('L','').decode('hex')[::-1].ljust(l,'\x00')
+    return hex(s)[2:].rjust(2 * l, '0').replace('L',
+                                                '').decode('hex')[::-1].ljust(
+                                                    l, '\x00'
+                                                )
+
 
 class FileStructure(dict):
     r"""
@@ -97,11 +194,11 @@ class FileStructure(dict):
 
     Examples:
 
-        FILE structure with flags as 0xfbad1807 and _IO_buf_base and _IO_buf_end pointing to 0xcafebabe and 0xfacef00d
+        FILE structure with _flags as 0xfbad1807 and _IO_buf_base and _IO_buf_end pointing to 0xcafebabe and 0xfacef00d
 
         >>> context.clear(arch='amd64')
         >>> fileStr = FileStructure(null=0xdeadbeeef)
-        >>> fileStr.flags = 0xfbad1807
+        >>> fileStr._flags = 0xfbad1807
         >>> fileStr._IO_buf_base = 0xcafebabe
         >>> fileStr._IO_buf_end = 0xfacef00d
         >>> payload = str(fileStr)
@@ -134,121 +231,121 @@ class FileStructure(dict):
         >>> payload = fileStr.orange(io_list_all=0xfacef00d, vtable=0xcafebabe)
     """
 
-    vars_=[]
-    length={}
-    arch='amd64'
+    vars_ = []
+    length = {}
+    arch = 'amd64'
 
-    def __init__(self,null=0):
-            self.vars_=[variables[i]['name'] for i in sorted(variables.keys())]
-            self.update({v:0 for v in self.vars_})
-            self.update(get_defaults(null))
-            self['_offset']=0xffffffffffffffff
-            self.arch=context.arch
-            if self.arch=='i386':
-                self.length=update_var(4)
-                self['_old_offset']=0xffffffff
-            else:
-                self.length=update_var(8)
-                self['_old_offset']=0xffffffffffffffff
-
-    def __setattr__(self,item,value):
-        if item in FileStructure.__dict__:
-            object.__setattr__(self,item,value)
+    def __init__(self, null=0):
+        self.vars_ = [variables[i]['name'] for i in sorted(variables.keys())]
+        self.update({v: 0 for v in self.vars_})
+        self.update(get_defaults(null))
+        self['_offset'] = 0xffffffffffffffff
+        self.arch = context.arch
+        if self.arch == 'i386':
+            self.length = update_var(4)
+            self['_old_offset'] = 0xffffffff
         else:
-            self.set_vars(item,value)
+            self.length = update_var(8)
+            self['_old_offset'] = 0xffffffffffffffff
 
-    def __getattr__(self,item):
+    def __setattr__(self, item, value):
+        if item in FileStructure.__dict__:
+            object.__setattr__(self, item, value)
+        else:
+            self.set_vars(item, value)
+
+    def __getattr__(self, item):
         return self[item]
 
-    def __setitem__(self,item,value):
+    def __setitem__(self, item, value):
         if item not in self.vars_:
             log.error("Unknown variable %r" % item)
-        return super(FileStructure,self).__setitem__(item,value)
+        return super(FileStructure, self).__setitem__(item, value)
 
     '''
     This defination for __repr__ to order the structure members. Useful when viewing a structure objet in python/IPython shell
     '''
 
     def __repr__(self):
-        d=self.sort_str()
-        return "{"+ "\n".join((" %r: %s" % (k,hex(v))) for k,v in d)+"}"
+        d = self.sort_str()
+        return "{" + "\n".join((" %r: %s" % (k, hex(v))) for k, v in d) + "}"
 
     def __len__(self):
         return len(str(self))
 
     def __str__(self):
-        structure=''
+        structure = ''
         for val in self.vars_:
             if type(self[val]) is str:
-                if self.arch=='i386':
-                    structure+=self[val].ljust(4,'\x00')
+                if self.arch == 'i386':
+                    structure += self[val].ljust(4, '\x00')
                 else:
-                    structure+=self[val].ljust(8,'\x00')
+                    structure += self[val].ljust(8, '\x00')
             else:
-                structure+=packit(self[val],self.length[val])
+                structure += packit(self[val], self.length[val])
         return structure
 
     def sort_str(self):
-        d=self.items()
-        d.sort(key=lambda x:self.vars_.index(x[0]))
+        d = self.items()
+        d.sort(key=lambda x: self.vars_.index(x[0]))
         return d
 
-    def set_vars(self,item,value):
-        self[item]=value
+    def set_vars(self, item, value):
+        self[item] = value
 
-    def struntil(self,v):
+    def struntil(self, v):
         if v not in self.vars_:
             return ''
-        structure=''
+        structure = ''
         for val in self.vars_:
             if type(self[val]) is str:
-                if self.arch=='i386':
-                    structure+=self[val].ljust(4,'\x00')
+                if self.arch == 'i386':
+                    structure += self[val].ljust(4, '\x00')
                 else:
-                    structure+=self[val].ljust(8,'\x00')
+                    structure += self[val].ljust(8, '\x00')
             else:
-                structure+=packit(self[val],self.length[val])
-            if val==v:
+                structure += packit(self[val], self.length[val])
+            if val == v:
                 break
-        return structure[:len(structure)-1]
+        return structure[:len(structure) - 1]
 
-    def write(self,addr=0,size=0):
-        self['flags'] &=~8
-        self['flags'] |=0x800
+    def write(self, addr=0, size=0):
+        self['_flags'] &= ~8
+        self['_flags'] |= 0x800
         self['_IO_write_base'] = addr
-        self['_IO_write_ptr'] = addr+size
+        self['_IO_write_ptr'] = addr + size
         self['_IO_read_end'] = addr
-        self['fileno'] = 1
-        return self.struntil('fileno')
+        self['_fileno'] = 1
+        return self.struntil('_fileno')
 
-    def read(self,addr=0,size=0):
-        self['flags'] &=~4
+    def read(self, addr=0, size=0):
+        self['_flags'] &= ~4
         self['_IO_read_base'] = 0
         self['_IO_read_ptr'] = 0
         self['_IO_buf_base'] = addr
-        self['_IO_buf_end'] = addr+size
-        self['fileno'] = 0
-        return self.struntil('fileno')
+        self['_IO_buf_end'] = addr + size
+        self['_fileno'] = 0
+        return self.struntil('_fileno')
 
-    def orange(self,io_list_all,vtable):
-        if self.arch=='amd64':
-            self['flags']='/bin/sh\x00'
-            self['_IO_read_ptr']=0x61
-            self['_IO_read_base']=io_list_all-0x10
+    def orange(self, io_list_all, vtable):
+        if self.arch == 'amd64':
+            self['_flags'] = '/bin/sh\x00'
+            self['_IO_read_ptr'] = 0x61
+            self['_IO_read_base'] = io_list_all - 0x10
         else:
-            self['flags']='sh\x00'
-            self['_IO_read_ptr']=0x121
-            self['_IO_read_base']=io_list_all-0x8
-        self['_IO_write_base']=0
-        self['_IO_write_ptr']=1
-        self['vtable']=vtable
+            self['_flags'] = 'sh\x00'
+            self['_IO_read_ptr'] = 0x121
+            self['_IO_read_base'] = io_list_all - 0x8
+        self['_IO_write_base'] = 0
+        self['_IO_write_ptr'] = 1
+        self['vtable'] = vtable
         return self.__str__()
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     from doctest import testmod
     from IPython import embed
-    context.arch='amd64'
+    context.arch = 'amd64'
     q = FileStructure(null=0xdeadbeef)
     testmod()
     embed()


### PR DESCRIPTION
Hi, I mainly changes
1. rm log variable and add `from pwn import *`, as we may use log.success.
2. add _mode and some other variables as in house of orange we need this variable.
3. make the variable name just like the name in FILE struct.

And also, I think may be there should some ways to modify the file struct more freedom.. because we may always need set the fp header to be `/bin/sh`, but for now, I am using `/bin/sh\x00`+str(fp)[8:], which is a little ugly..
